### PR TITLE
Fix case when fractional parts are different in length

### DIFF
--- a/round_percentages/round_percentages.py
+++ b/round_percentages/round_percentages.py
@@ -13,7 +13,7 @@ def round_percentages(percentages):
     for index, percentage in enumerate(percentages):
         integer, decimal = str(float(percentage)).split('.')
         integer = int(integer)
-        decimal = int(decimal)
+        decimal = float(f'0.{decimal}')
 
         result.append([integer, decimal, index])
         sum_of_integer_parts += integer

--- a/tests.py
+++ b/tests.py
@@ -22,6 +22,13 @@ class TestRoundedPercentages(unittest.TestCase):
         self.assertEqual(result, input_)
         self.assertEqual(sum(result), 100)
 
+    def test_different_fractional_part_length(self):
+        input_ = [31.4952, 42.803, 25.7018]
+        self.assertEqual(sum(input_), 100)
+
+        result = round_percentages(input_)
+        self.assertEqual(result,  [31, 43, 26])
+        self.assertEqual(sum(result), 100)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When percentages have different lengths of fractional parts algorithm rounds them in the wrong way.

For example, following percentages `[31.4952, 42.803, 25.7018]` are rounded to `[32, 42, 26]`.